### PR TITLE
Prompt user to choose import

### DIFF
--- a/src/com/haskforce/highlighting/annotation/external/GhcMod.java
+++ b/src/com/haskforce/highlighting/annotation/external/GhcMod.java
@@ -325,7 +325,7 @@ public class GhcMod {
                                     annotation.registerFix(new AddLanguagePragma(matcher.group(1)));
                                 }
                             }),
-                    Pair.create(Pattern.compile("Variable not in scope: ([^ ]+) "),
+                    Pair.create(Pattern.compile("Variable not in scope:\\s+([^ ]+) "),
                             new RegisterFixHandler() {
                                 @Override
                                 public void apply(Matcher matcher, Annotation annotation, Problem problem) {

--- a/src/com/haskforce/highlighting/annotation/external/SymbolImportProvider.scala
+++ b/src/com/haskforce/highlighting/annotation/external/SymbolImportProvider.scala
@@ -5,5 +5,7 @@ trait SymbolImportProvider {
 }
 
 object SymbolImportProvider {
-  final case class Result(importText: String, symbolText: String)
+  final case class Result(importText: String, symbolText: String) {
+    override def toString: String = s"$importText ($symbolText)"
+  }
 }


### PR DESCRIPTION
This just gets it to where we actually prompt the user to choose the import, and fixes a bug in locating the identifier name in the regex.  We should consider using `QuestionAction` instead of `BaseIntentionAction` since that's what it looks like both Java and Scala use for their auto-add import feature.

Java support - https://upsource.jetbrains.com/idea-ce/file/idea-ce-1ef68923b2a9475d80173155d83bb7c1872694aa/java/java-impl/src/com/intellij/codeInsight/daemon/impl/actions/AddImportAction.java?nav=3617:5931:focused&line=215

Scala support - https://github.com/JetBrains/intellij-scala/blob/idea173.x/scala/scala-impl/src/org/jetbrains/plugins/scala/annotator/intention/ScalaImportTypeFix.scala